### PR TITLE
Fixed small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ type foo struct {
 
 func newFoo() (*foo, error) {
 	return &foo{
-		Message:  "foo",
+		Message:  "foo loves bar",
 		Ports: []int{80},
 		ServerName: "Foo",
 	}, nil


### PR DESCRIPTION
I updated example for Snippet in lines 689-713 to reflect example output given on line 750.

If I understood and done everything correctly output of current example is actually:

```
string(out) = {"Message":"foo","Ports":[80],"ServerName":"Foo"}
```

Because ServerName is already Foo, I decided to change Message to "foo loves bar"
