### PR TITLE
`referrers` is a mode of guru, not vim-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1542,7 +1542,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 ```
 
 Put your cursor on top of the `handler` and call `:GoReferrers`. This calls the
-`referrers` mode of `vim-go`, which finds references to the selected identifier,
+`referrers` mode of `guru`, which finds references to the selected identifier,
 scanning all necessary packages within the workspace. The result will be a
 quickfix list, so you should be able to jump to the results easily.
 


### PR DESCRIPTION
Just a small fix...