### PR TITLE
Update to reflect go_highlight_function_calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,16 +848,34 @@ If we add the following:
 
 ```vim
 let g:go_highlight_functions = 1
-let g:go_highlight_methods = 1
 ```
 
-We are now also highlighting function names. `Foo` and `main` will now
-be highlighted:
+We are now also highlighting function and method names in declarations. `Foo`
+and `main` will now be highlighted, but `Println` is not as that is an
+invocation:
 
 ```go
 func (t *T) Foo() {}
 
 func main() {
+  fmt.Println("vim-go")
+}
+```
+
+If you also want to highlight function and method invocations, add the
+following:
+
+```vim
+let g:go_highlight_function_calls = 1
+```
+
+Now, `Println` will also be highlighted:
+
+```go
+func (t *T) Foo() {}
+
+func main() {
+  fmt.Println("vim-go")
 }
 ```
 

--- a/vimrc
+++ b/vimrc
@@ -113,7 +113,7 @@ let g:go_list_type = "quickfix"
 let g:go_highlight_types = 1
 let g:go_highlight_fields = 1
 let g:go_highlight_functions = 1
-let g:go_highlight_methods = 1
+let g:go_highlight_function_calls = 1
 let g:go_highlight_extra_types = 1
 let g:go_highlight_generate_tags = 1
 


### PR DESCRIPTION
With the elimination of go_highlight_methods and the addition of
go_highlight_function_calls, the tutorial needs to be updated, as
does the sample included vimrc file.

As a newcomer to vim-go, it took me a few minutes to chase down
why I thought the syntax highlighting was not working (and almost
bailed back to vscode).