### PR TITLE
added a command to source vimrc, before :PlugInstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ a part of the function declaration or not?)
 ### Struct split and join
 There is a great plugin that allows you to split or join Go structs. It's
 actually not a Go plugin, but it has support for Go structs. To enable it add
-plugin directive between the `plug` definition into your `vimrc` and run
+plugin directive between the `plug` definition into your `vimrc`, then do a `:source ~/.vimrc` in your vim editor and run
 `:PlugInstall`. Example:
 
 ```vim
@@ -662,7 +662,7 @@ Vim-go supports two popular snippet plugins.
 [Ultisnips](https://github.com/SirVer/ultisnips) and
 [neosnippet](https://github.com/Shougo/neosnippet.vim). By default, 
 if you have `Ultisnips` installed it'll work.  Let us install `ultisnips`
-first. Add it between the `plug` directives in your `vimrc` and then run
+first. Add it between the `plug` directives in your `vimrc`, then do a `:source ~/.vimrc` in your vim editor and then run
 `:PlugInstall`. Example:
 
 ```vim
@@ -977,7 +977,7 @@ let g:molokai_original = 1
 colorscheme molokai
 ```
 
-After that restart Vim and call `:PlugInstall`. This will pull the plugin
+After that restart Vim and call `:source ~/.vimrc`, then `:PlugInstall`. This will pull the plugin
 and install it for you. After the plugin is installed, you need to restart Vim
 again.
 
@@ -1162,7 +1162,7 @@ a certain plugin. The commands are:
 First let us enable these two commands by installing the necessary plugin. The
 plugin is called [ctrlp](https://github.com/ctrlpvim/ctrlp.vim). Long-time Vim
 users have it installed already. To install it add the following line between
-your `plug` directives and call `:PlugInstall` to install it:
+your `plug` directives, then do a `:source ~/.vimrc` in your vim editor and call `:PlugInstall` to install it:
 
 ```vim
 Plug 'ctrlpvim/ctrlp.vim'


### PR DESCRIPTION
Hi, 

I'm new to vim, and as i follow this tutorial (p.s. Which is great), I notice that :PlugInstall's main purpose is to download or clone the plugin from their respective repositories and install to our machine.

However to do this we need to source the .vimrc file, which we can't do in bash or zsh(terminal). We should instead do it on our vim editor.

Hence I propose an update to the README, by adding this command before :PlugInstall . Hopefully this will help beginers like me. 

Cheers 